### PR TITLE
FEAT: Add support for additional types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to **ValueStringBuilder** will be documented in this file. T
 
 ## [Unreleased]
 
+## [0.7.1] - 2023-08-22
+
+### Added 
+ - The string builder can now be used to append integers, boolean & collection of strings. `sb.AppendInt(1).AppendBool(true).AppendList([]string{"a", "b", "c"})`
+
 ## [0.7.0] - 2023-08-21
 
 \### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ All notable changes to **ValueStringBuilder** will be documented in this file. T
 
 ## [Unreleased]
 
-## [0.7.1] - 2023-08-22
-
 ### Added 
  - The string builder can now be used to append integers, boolean & collection of strings. `sb.AppendInt(1).AppendBool(true).AppendList([]string{"a", "b", "c"})`
 

--- a/stringbuilder.go
+++ b/stringbuilder.go
@@ -26,14 +26,10 @@ func NewStringBuilderFromString(text string) *StringBuilder {
 
 // Appends a text to the StringBuilder instance
 func (s *StringBuilder) Append(text string) *StringBuilder {
+	s.resize(text)
 	textRunes := []rune(text)
-	newLen := s.position + len(textRunes)
-	if newLen > cap(s.data) {
-		s.grow(newLen)
-	}
-
 	copy(s.data[s.position:], textRunes)
-	s.position = newLen
+	s.position = s.position + len(textRunes)
 
 	return s
 }
@@ -52,7 +48,6 @@ func (s *StringBuilder) AppendRune(char rune) *StringBuilder {
 	if newLen > cap(s.data) {
 		s.grow(newLen)
 	}
-
 	s.data[s.position] = char
 	s.position++
 
@@ -65,16 +60,28 @@ func (s *StringBuilder) AppendInt(integer int) *StringBuilder {
 }
 
 // Appends a single boolean to the StringBuilder instance
-func (s *StringBuilder) AppendBoolean(flag bool) *StringBuilder {
+func (s *StringBuilder) AppendBool(flag bool) *StringBuilder {
 	return s.Append(strconv.FormatBool(flag))
 }
 
 // Appends a list of strings to the StringBuilder instance
 func (s *StringBuilder) AppendList(words []string) *StringBuilder {
+	s.resize(words...)
 	for _, word := range words {
 		s = s.Append(word)
 	}
 	return s
+}
+
+func (s *StringBuilder) resize(words ...string) {
+	allWordLength := 0
+	for _, word := range words {
+		allWordLength += len(word)
+	}
+	newLen := s.position + allWordLength
+	if newLen > cap(s.data) {
+		s.grow(newLen)
+	}
 }
 
 // Returns the current length of the represented string

--- a/stringbuilder.go
+++ b/stringbuilder.go
@@ -1,6 +1,9 @@
 package Text
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+)
 
 type StringBuilder struct {
 	data     []rune
@@ -19,6 +22,10 @@ func NewStringBuilderFromString(text string) *StringBuilder {
 		data:     textRunes,
 		position: len(textRunes),
 	}
+}
+
+type SupportedTypes interface {
+	string | int
 }
 
 // Appends a text to the StringBuilder instance
@@ -53,6 +60,21 @@ func (s *StringBuilder) AppendRune(char rune) *StringBuilder {
 	s.data[s.position] = char
 	s.position++
 
+	return s
+}
+
+func (s *StringBuilder) AppendInt(integer int) *StringBuilder {
+	return s.Append(strconv.Itoa(integer))
+}
+
+func (s *StringBuilder) AppendBoolean(flag bool) *StringBuilder {
+	return s.Append(strconv.FormatBool(flag))
+}
+
+func (s *StringBuilder) AppendList(words []string) *StringBuilder {
+	for _, word := range words {
+		s = s.Append(word)
+	}
 	return s
 }
 

--- a/stringbuilder.go
+++ b/stringbuilder.go
@@ -59,14 +59,17 @@ func (s *StringBuilder) AppendRune(char rune) *StringBuilder {
 	return s
 }
 
+// Appends a single integer to the StringBuilder instance
 func (s *StringBuilder) AppendInt(integer int) *StringBuilder {
 	return s.Append(strconv.Itoa(integer))
 }
 
+// Appends a single boolean to the StringBuilder instance
 func (s *StringBuilder) AppendBoolean(flag bool) *StringBuilder {
 	return s.Append(strconv.FormatBool(flag))
 }
 
+// Appends a list of strings to the StringBuilder instance
 func (s *StringBuilder) AppendList(words []string) *StringBuilder {
 	for _, word := range words {
 		s = s.Append(word)

--- a/stringbuilder.go
+++ b/stringbuilder.go
@@ -24,10 +24,6 @@ func NewStringBuilderFromString(text string) *StringBuilder {
 	}
 }
 
-type SupportedTypes interface {
-	string | int
-}
-
 // Appends a text to the StringBuilder instance
 func (s *StringBuilder) Append(text string) *StringBuilder {
 	textRunes := []rune(text)

--- a/stringbuilder_test.go
+++ b/stringbuilder_test.go
@@ -26,6 +26,27 @@ func TestAppend(t *testing.T) {
 	}
 }
 
+func TestAppendMultipleTypes(t *testing.T) {
+	tests := []struct {
+		stringInput     string
+		intInput        int
+		booleanInput    bool
+		multipleStrings []string
+		want            string
+	}{
+		{"hello", 123, false, []string{"a", "b", "c"}, "hello123falseabc"},
+		{"hello", 123, true, []string{"a", "b", "c"}, "hello123trueabc"},
+	}
+	for _, tt := range tests {
+		s := &StringBuilder{}
+		s.Append(tt.stringInput).AppendInt(tt.intInput).AppendBoolean(tt.booleanInput).AppendList(tt.multipleStrings)
+
+		if got := s.ToString(); got != tt.want {
+			t.Errorf("StringBuilder.Append Multiple types = %v, want %v", got, tt.want)
+		}
+	}
+}
+
 func TestLen(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/stringbuilder_test.go
+++ b/stringbuilder_test.go
@@ -39,7 +39,7 @@ func TestAppendMultipleTypes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		s := &StringBuilder{}
-		s.Append(tt.stringInput).AppendInt(tt.intInput).AppendBoolean(tt.booleanInput).AppendList(tt.multipleStrings)
+		s.Append(tt.stringInput).AppendInt(tt.intInput).AppendBool(tt.booleanInput).AppendList(tt.multipleStrings)
 
 		if got := s.ToString(); got != tt.want {
 			t.Errorf("StringBuilder.Append Multiple types = %v, want %v", got, tt.want)


### PR DESCRIPTION
This code changes comes from the discussion under https://github.com/linkdotnet/golang-stringbuilder/issues/1#issuecomment-1686436659

**What is changed?**
 - Added support for appending Int to StringBuilder
 - Added support for appending Boolean to StringBuilder
 - Added support for appending list of strings to StringBuilder

**What didn't work**
My initial thought process while approaching this change was to leverage generics. But I made a mistake of thinking that generics support in Golang is equivalent to that of other programming languages. With Go's generics support, something such as below is not possible

```
func (s *StringBuilder) AppendLine[T any](t T) *StringBuilder
```
More details: https://www.reddit.com/r/golang/comments/tvfbow/the_fact_that_methods_are_not_allowed_to_have/

Ok. So let's try another approach. Let's just create multiple `Append` methods with different types. Good old method overloading. Ehhh. Golang does not even supports that in a clean manner. More details: https://stackoverflow.com/a/6987002/3938227

**What worked**
Adding separate methods for each type does the job. Though it is not a clean abstraction as that of other programming languages such as Java(https://docs.oracle.com/javase/8/docs/api/java/lang/StringBuilder.html), it gets the job done. 

**NOTE**
This is more of a POC. If this looks good, I can extend this PR to support the remaining types as described under the above API spec of Java's StringBuilder implementation
