### PR TITLE
Added Reverse StringBuilder functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to **ValueStringBuilder** will be documented in this file. T
 
 ## [Unreleased]
 
+### Added
+
+- `Reverse` is added to the string builder
+
 ## [0.9.0] - 2023-08-26
 
 ### Added

--- a/stringbuilder.go
+++ b/stringbuilder.go
@@ -280,6 +280,15 @@ func (s *StringBuilder) AsRuneArray() []rune {
 	return s.data
 }
 
+// Reverses the characters of a string builder
+func (s *StringBuilder) Reverse() *StringBuilder {
+	for left, right := 0, s.position-1; left < right; left, right = left+1, right-1 {
+		s.data[left], s.data[right] = s.data[right], s.data[left]
+	}
+
+	return s
+}
+
 func (s *StringBuilder) grow(lenToAdd int) {
 	// Grow times 2 until lenToAdd fits
 	newLen := len(s.data)

--- a/stringbuilder_test.go
+++ b/stringbuilder_test.go
@@ -407,6 +407,43 @@ func TestTrimWithWhitespacesAtTheStartAndEnd(t *testing.T) {
 	}
 }
 
+func TestReverseStringBuilder(t *testing.T) {
+	tests := []struct {
+		name   string
+		insert []string
+		want   string
+	}{
+		{"Reverse odd length string builder", []string{"A", "B", "C"}, "CBA"},
+		{"Reverse even length string builder", []string{"A", "B"}, "BA"},
+		{"Reverse string builder of size 1", []string{"A"}, "A"},
+		{"Reverse empty string builder", []string{}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sb := &StringBuilder{}
+
+			for _, s := range tt.insert {
+				sb = sb.Append(s)
+			}
+
+			sb = sb.Reverse()
+
+			if got := sb.ToString(); got != tt.want {
+				t.Errorf("StringBuilder.Reverse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReuseReversedStringBuilder(t *testing.T) {
+	sb := StringBuilder{}
+
+	sb = *sb.Append("A").Append("B").Append("C").Reverse().Append("X")
+	if got := sb.ToString(); got != "CBAX" {
+		t.Errorf("StringBuilder.Reverse() = %v, want %v", got, "CBAX")
+	}
+}
+
 func slicesEqual(a []int, b []int) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
**Changes:**
 - Added StringBuilder `Reverse` functionality
 - Added tests to verify correctness of `Reverse` functionality
 - Added tests to verify reuse of reversed string builder

This is to address the feature request discussed under https://github.com/linkdotnet/golang-stringbuilder/issues/4