### PR TITLE
Make StringBuilder thread-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to **ValueStringBuilder** will be documented in this file. T
 
 ### Changed
 - Refactored search functions
+- Make StringBuilder thread-safe
 
 ## [0.10.0] - 2023-08-31
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GoDoc](https://pkg.go.dev/badge/github.com/linkdotnet/golang-stringbuilder?status.svg)](https://pkg.go.dev/github.com/linkdotnet/golang-stringbuilder?tab=doc)
 
 # golang-stringbuilder
-A string builder that has similar capabilities as the one from C#. The goal is to have a straightforward API that lets you work with strings easily.
+A string builder that has similar capabilities as the one from C#. The goal is to have a straightforward API that lets you work with strings easily. All the mutations on the `StringBuilder` are thread-safe. 
 
 ## Install
 

--- a/stringbuilder.go
+++ b/stringbuilder.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 )
 
+// StringBuilder is a thread-safe & mutable sequence of characters
 type StringBuilder struct {
 	data     []rune
 	position int

--- a/stringbuilder_test.go
+++ b/stringbuilder_test.go
@@ -428,6 +428,27 @@ func TestReplaceRune(t *testing.T) {
 	}
 }
 
+func TestReplaceRuneConcurrent(t *testing.T) {
+	sb := NewStringBuilderFromString("Hello")
+
+	var wg sync.WaitGroup
+	wg.Add(NumOfThreads)
+	for i := 0; i < NumOfThreads; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < NumOfIterations; j++ {
+				sb.ReplaceRune('l', 'm')
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if got := sb.ToString(); got != "Hemmo" {
+		t.Errorf("StringBuilder.ReplaceRune() = %v, want %v", got, "Hemmo")
+	}
+}
+
 func TestReplace(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -541,6 +562,28 @@ func TestReuseReversedStringBuilder(t *testing.T) {
 	sb = *sb.Append("A").Append("B").Append("C").Reverse().Append("X")
 	if got := sb.ToString(); got != "CBAX" {
 		t.Errorf("StringBuilder.Reverse() = %v, want %v", got, "CBAX")
+	}
+}
+
+func TestReverseStringBuilderConcurrent(t *testing.T) {
+	sb := NewStringBuilderFromString("ABC")
+
+	var wg sync.WaitGroup
+	wg.Add(NumOfThreads)
+	for i := 0; i < NumOfThreads; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < NumOfIterations; j++ {
+				sb = sb.Reverse()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	expected := "ABC" // We expect the original string as we have reversed NumOfThreads * NumOfIterations times which is even
+	if got := sb.ToString(); got != expected {
+		t.Errorf("StringBuilder.Reverse() = %v, want %v", got, expected)
 	}
 }
 


### PR DESCRIPTION
**Changes:**
 - Introduced `sync.Mutex` under `StringBuilder` struct
 - Made use of mutex for all the mutation operations
 - Extracted some mutation functionality to private function so that mutex can be used while invoking common functionality(`insert` & `remove`)
 - Moved all the private functions after all the public function declaration
 - Added tests to verify correctness while mutating concurrently with multiple threads

**Benchmark result with mutex**
```
go test -bench=.                                                            
goos: darwin
goarch: arm64
pkg: github.com/linkdotnet/golang-stringbuilder
BenchmarkStringBuilderConcat-10      	  355993	      3337 ns/op
BenchmarkStringConcat-10             	 1000000	      1049 ns/op
BenchmarkGoStringBuilderConcat-10    	 4382754	       271.4 ns/op
PASS
ok  	github.com/linkdotnet/golang-stringbuilder	4.839s
```

**Note:** All the mutation operations are concurrent but read operations are not thread-safe so a user might be able to see partial results while reading. For example consider an empty `StringBuilder`:
`AppendList` is a multi-step operation so if thread `T1` is appending a list with strings `A, B, C` and thread `T2` invokes `ToString` then they might see partially updated value as `A` or `AB` or `ABC`(Complete update).
